### PR TITLE
engine command not using the correct logging verboisty flag. verbosit…

### DIFF
--- a/rulesys/main.go
+++ b/rulesys/main.go
@@ -165,7 +165,7 @@ func engine(args []string, wg *sync.WaitGroup) []string {
 		}
 	}
 
-	verb, err := core.ParseVerbosity(*verbosity)
+	verb, err := core.ParseVerbosity(*accVerbosity)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
…y not on engine flags, changed to use acc-verbosity flag