### PR TITLE
feat(storage): added cassandra scan error handling and retry policy

### DIFF
--- a/core/location.go
+++ b/core/location.go
@@ -178,12 +178,13 @@ func (loc *Location) init(ctx *Context) error {
 
 	ctx.SetLoc(loc)
 	loc.loading = true
-	if err := loc.state.Load(ctx); err != nil {
+	err := loc.state.Load(ctx)
+	loc.loading = false
+	if err != nil {
 		Log(ERROR, ctx, "Location.init", "error", err, "when", "State.Load", "location", loc.Name)
 	}
-	loc.loading = false
 
-	return nil
+	return err
 }
 
 func (loc *Location) StateSize(ctx *Context) (int, error) {

--- a/core/location.go
+++ b/core/location.go
@@ -180,10 +180,10 @@ func (loc *Location) init(ctx *Context) error {
 	loc.loading = true
 	err := loc.state.Load(ctx)
 	loc.loading = false
+
 	if err != nil {
 		Log(ERROR, ctx, "Location.init", "error", err, "when", "State.Load", "location", loc.Name)
 	}
-
 	return err
 }
 

--- a/storage/cassandra/cassandra.go
+++ b/storage/cassandra/cassandra.go
@@ -21,8 +21,10 @@ package cassandra
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gocql/gocql"
 
@@ -46,22 +48,31 @@ type CassStorage struct {
 // This name stutters because it's convenient to dot-import core,
 // which defines 'Storage'.
 type CassandraDBConfig struct {
-	nodes    []string
-	username string
-	password string
-	keyspace string
+	nodes          []string
+	username       string
+	password       string
+	keyspace       string
+	timeout        time.Duration
+	backoffRetries int
+	backoffMin     time.Duration
+	backoffMax     time.Duration
 }
 
 // ParseConfig generates a CassandraDBConfig from a string.
 // Configuration is parsed from a string of the follow format:
 // host:port,host:port;username;password;keyspace
 func ParseConfig(config string) (*CassandraDBConfig, error) {
+	var err error
 	var ns []string
 	user := ""
 	pass := ""
 	ks := ""
+	timeout := time.Second
+	backoffRetries := 4
+	backoffMin := 100 * time.Millisecond
+	backoffMax := 10 * time.Second
 
-	parts := strings.SplitN(config, ";", 4)
+	parts := strings.Split(config, ";")
 
 	if 0 < len(parts) && parts[0] != "" {
 		hostPorts := strings.Split(parts[0], ",")
@@ -84,11 +95,43 @@ func ParseConfig(config string) (*CassandraDBConfig, error) {
 		ks = parts[3]
 	}
 
+	if 4 < len(parts) && parts[4] != "" {
+		timeout, err = time.ParseDuration(parts[4])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if 5 < len(parts) && parts[5] != "" {
+		backoffRetries, err = strconv.Atoi(parts[5])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if 6 < len(parts) && parts[6] != "" {
+		backoffMin, err = time.ParseDuration(parts[6])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if 7 < len(parts) && parts[7] != "" {
+		backoffMax, err = time.ParseDuration(parts[7])
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	c := CassandraDBConfig{
-		nodes:    ns,
-		username: user,
-		password: pass,
-		keyspace: ks,
+		nodes:          ns,
+		username:       user,
+		password:       pass,
+		keyspace:       ks,
+		timeout:        timeout,
+		backoffRetries: backoffRetries,
+		backoffMin:     backoffMin,
+		backoffMax:     backoffMax,
 	}
 
 	return &c, nil
@@ -125,6 +168,12 @@ func (s *CassStorage) init(ctx *Context, config CassandraDBConfig) error {
 			Username: config.username,
 			Password: config.password,
 		}
+	}
+	s.cluster.Timeout = config.timeout
+	s.cluster.RetryPolicy = &gocql.ExponentialBackoffRetryPolicy{
+		config.backoffRetries,
+		config.backoffMin,
+		config.backoffMax,
 	}
 	// How to create Cassandra data structures.
 
@@ -185,16 +234,20 @@ func (s *CassStorage) init(ctx *Context, config CassandraDBConfig) error {
 func (s *CassStorage) Load(ctx *Context, loc string) ([]Pair, error) {
 	Log(INFO, ctx, "CassStorage.Load", "location", loc)
 
-	iter := s.session.Query(`SELECT data FROM locstate WHERE loc = ?`, loc).Iter()
+	q := s.session.Query(`SELECT data FROM locstate WHERE loc = ?`, loc)
 	acc := make([]Pair, 0, 1024)
 
 	var pairs map[string]string
 
-	if iter.Scan(&pairs) {
+	if err := q.Scan(&pairs); err == nil {
 		for k, v := range pairs {
 			d := Pair{[]byte(k), []byte(v)}
 			Log(DEBUG, ctx, "CassStorage.Load", "pair", d)
 			acc = append(acc, d)
+		}
+	} else {
+		if err != gocql.ErrNotFound {
+			return nil, fmt.Errorf("failed to scan cassandra DB: %w", err)
 		}
 	}
 

--- a/storage/cassandra/cassandra.go
+++ b/storage/cassandra/cassandra.go
@@ -48,14 +48,14 @@ type CassStorage struct {
 // This name stutters because it's convenient to dot-import core,
 // which defines 'Storage'.
 type CassandraDBConfig struct {
-	nodes          []string
+	Nodes          []string
 	username       string
 	password       string
 	keyspace       string
-	timeout        time.Duration
-	backoffRetries int
-	backoffMin     time.Duration
-	backoffMax     time.Duration
+	Timeout        time.Duration
+	BackoffRetries int
+	BackoffMin     time.Duration
+	BackoffMax     time.Duration
 }
 
 // ParseConfig generates a CassandraDBConfig from a string.
@@ -124,14 +124,14 @@ func ParseConfig(config string) (*CassandraDBConfig, error) {
 	}
 
 	c := CassandraDBConfig{
-		nodes:          ns,
+		Nodes:          ns,
 		username:       user,
 		password:       pass,
 		keyspace:       ks,
-		timeout:        timeout,
-		backoffRetries: backoffRetries,
-		backoffMin:     backoffMin,
-		backoffMax:     backoffMax,
+		Timeout:        timeout,
+		BackoffRetries: backoffRetries,
+		BackoffMin:     backoffMin,
+		BackoffMax:     backoffMax,
 	}
 
 	return &c, nil
@@ -139,7 +139,7 @@ func ParseConfig(config string) (*CassandraDBConfig, error) {
 
 // NewStorage creates new Storage implementation based on Cassandra.
 //
-// The given nodes should have the form ADDRESS:PORT, where the PORT
+// The given Nodes should have the form ADDRESS:PORT, where the PORT
 // is the CQL port (normally 9042, I think).
 func NewStorage(ctx *Context, config CassandraDBConfig) (*CassStorage, error) {
 	cassStoreMutex.Lock()
@@ -161,7 +161,7 @@ func (s *CassStorage) init(ctx *Context, config CassandraDBConfig) error {
 	Log(INFO, ctx, "CassStorage.init", "config", config)
 
 	// ToDo: Expose more/better Cass connection parameters
-	s.cluster = gocql.NewCluster(config.nodes...)
+	s.cluster = gocql.NewCluster(config.Nodes...)
 	s.cluster.Consistency = gocql.Quorum
 	if config.username != "" {
 		s.cluster.Authenticator = gocql.PasswordAuthenticator{
@@ -169,11 +169,11 @@ func (s *CassStorage) init(ctx *Context, config CassandraDBConfig) error {
 			Password: config.password,
 		}
 	}
-	s.cluster.Timeout = config.timeout
+	s.cluster.Timeout = config.Timeout
 	s.cluster.RetryPolicy = &gocql.ExponentialBackoffRetryPolicy{
-		config.backoffRetries,
-		config.backoffMin,
-		config.backoffMax,
+		config.BackoffRetries,
+		config.BackoffMin,
+		config.BackoffMax,
 	}
 	// How to create Cassandra data structures.
 


### PR DESCRIPTION
This MR adds a tiny bit of much-needed improvements to the way errors reaching cassandra hosts are handled.

# Goals
* propagate errors in scanning cassandra database
* add exponential backoff retry policy to cassandra
* add configurable timeout to cassandra