### PR TITLE
Add option for 'or' operations to short circuit

### DIFF
--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -335,6 +335,18 @@ Example query:
 query.  An `and` or `or` value should be an array of subqueries.  A
 `not` value is a single subquery.
 
+The `or` query supports an optional `shortCircuit` flag. By default
+`or` queries are exhaustive: all subqueries will be executed.  When
+`shortCircuit` is set, the query terminates after the first subquery 
+returns bindings. For example, the below query would terminate if 
+the `?likes` pattern produces bindings.
+
+```Javascript
+{"or": [{"pattern":{"likes":"?likes"}},
+        {"pattern":{"drinks":"?drinks"}}],
+"shortCircuit":true}
+```
+
 A `code` value is string of Javascript or an array of strings of
 Javascript.  When executed, the Javascript environment includes
 bindings for all variables that are bound at that point in the query

--- a/doc/rule-schema.json
+++ b/doc/rule-schema.json
@@ -137,6 +137,10 @@
       "description": "Or operation",
       "type": "object",
       "properties": {
+        "shortCircuit": {
+          "description": "whether the or operation should stop after the first query that successfully returns bindings",
+          "type": "boolean"
+        },
         "or": {
           "description": "List of queries",
           "type": "array",


### PR DESCRIPTION
Fairly self-explanatory.  There's some room for improvement in the marshaling, but it would increase the scope of the MR more than I was looking for.