### PR TITLE
Rule Indexing link is broken.

### DIFF
--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -806,7 +806,7 @@ but our use cases mostly seemed to ignore the wildcard variable
 bindings.  (A previous implementation had wildcards; they could
 reappear if useful.)
 
-Note that [rule indexing](Design.md#processing) is harder when
+Note that [rule indexing](design.md#processing) is harder when
 matching can be partial.
 
 #### Matching Limitations


### PR DESCRIPTION
The current link results in a 404 `Page not found` - https://github.com/Comcast/rulio/blob/master/doc/Design.md#processing

The new link does not - https://github.com/Comcast/rulio/blob/master/doc/design.md#processing