### PR TITLE
fix(core): cast nested slices before matching

### DIFF
--- a/core/match.go
+++ b/core/match.go
@@ -91,7 +91,7 @@ func cast(iface interface{}) interface{} {
 		iface = v
 	default:
 		if v, ok := ISlice(v); ok {
-			iface = v
+			iface = cast(v)
 		}
 	}
 	return iface

--- a/core/match_test.go
+++ b/core/match_test.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCast(t *testing.T) {
+	t.Run("Nested Map Slices", func(t *testing.T) {
+		got := cast([]Map{
+			{
+				"another map slice": []Map{
+					{
+						"foo": "bar",
+					},
+				},
+			},
+		})
+		assert.Equal(t,
+			[]interface{}{
+				map[string]interface{}{
+					"another map slice": []interface{}{
+						map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			got,
+		)
+	})
+}


### PR DESCRIPTION
@jsccast bug got in through my PR https://github.com/Comcast/rulio/pull/70

Easy fix, though, and added a regression test.