### PR TITLE
User Query Processor

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -31,6 +31,11 @@ type App interface {
 	// UpdateJavascriptRuntime can be used to modify the
 	// Javascript environment for actions and condition code.
 	UpdateJavascriptRuntime(ctx *Context, runtime *otto.Otto) error
+
+	// ProcessQuery can be used to replace or wrap queries when unmarshaling a
+	// rule condition.  The method gets the raw generic query data along with
+	// the query created by Rulio.
+	ProcessQuery(ctx *Context, raw map[string]interface{}, query Query) Query
 }
 
 // Tracer can be used to perform application tracing.

--- a/core/events_test.go
+++ b/core/events_test.go
@@ -228,6 +228,10 @@ func (ba *BindingApp) UpdateJavascriptRuntime(ctx *Context, runtime *otto.Otto) 
 	return nil
 }
 
+func (ba *BindingApp) ProcessQuery(_ *Context, _ map[string]interface{}, q Query) Query {
+	return q
+}
+
 func TestEventConditionBindings(t *testing.T) {
 	ctx, loc := TestingLocation(t)
 	c := make(chan interface{})

--- a/core/http_test.go
+++ b/core/http_test.go
@@ -156,3 +156,7 @@ func (ha *HeaderApp) ProcessBindings(ctx *Context, bs Bindings) Bindings {
 func (ha *HeaderApp) UpdateJavascriptRuntime(ctx *Context, runtime *otto.Otto) error {
 	return nil
 }
+
+func (ha *HeaderApp) ProcessQuery(_ *Context, _ map[string]interface{}, q Query) Query {
+	return q
+}

--- a/core/query.go
+++ b/core/query.go
@@ -757,7 +757,7 @@ func ParseQuery(ctx *Context, m map[string]interface{}) (q Query, err error) {
 	}
 
 	defer func() {
-		if ctx.App != nil {
+		if ctx != nil && ctx.App != nil {
 			q = ctx.App.ProcessQuery(ctx, m, q)
 		}
 	}()

--- a/core/query.go
+++ b/core/query.go
@@ -750,17 +750,24 @@ func NotQueryFromMap(ctx *Context, m map[string]interface{}) (Query, bool, error
 	return q, true, nil
 }
 
-func ParseQuery(ctx *Context, m map[string]interface{}) (Query, error) {
+func ParseQuery(ctx *Context, m map[string]interface{}) (q Query, err error) {
 	Log(DEBUG, ctx, "core.ParseQuery", "map", fmt.Sprintf("%#v", m))
 	if len(m) == 0 {
 		return EmptyQuery{}, nil
 	}
+
+	defer func() {
+		if ctx.App != nil {
+			q = ctx.App.ProcessQuery(ctx, m, q)
+		}
+	}()
+
 	q, applicable, err := CodeQueryFromMap(ctx, m)
 	if applicable {
 		if err != nil {
 			return nil, err
 		} else {
-			return q, nil
+			return
 		}
 	}
 
@@ -769,7 +776,7 @@ func ParseQuery(ctx *Context, m map[string]interface{}) (Query, error) {
 		if err != nil {
 			return nil, err
 		} else {
-			return q, nil
+			return
 		}
 	}
 
@@ -778,7 +785,7 @@ func ParseQuery(ctx *Context, m map[string]interface{}) (Query, error) {
 		if err != nil {
 			return nil, err
 		} else {
-			return q, nil
+			return
 		}
 	}
 
@@ -787,7 +794,7 @@ func ParseQuery(ctx *Context, m map[string]interface{}) (Query, error) {
 		if err != nil {
 			return nil, err
 		} else {
-			return q, nil
+			return
 		}
 	}
 
@@ -796,7 +803,7 @@ func ParseQuery(ctx *Context, m map[string]interface{}) (Query, error) {
 		if err != nil {
 			return nil, err
 		} else {
-			return q, nil
+			return
 		}
 	}
 


### PR DESCRIPTION
Hi @jsccast 

This PR is to get a hook into the condition query structure via the user `App` interface by adding a new method `ProcessQuery()`.  The main motivation behind this is to be able to wrap queries in tracing for the purposes of debugging and test coverage calculation.

Adding to the `App` interface of course breaks existing implementations of the interface which update their Rulio dependency, but a trivial implementation of the new `ProcessQuery()` method is of course easy to create.

An illustrative test is included.