### PR TITLE
clean up javascript watchdogs with extra goroutine communication

### DIFF
--- a/core/javascript_test.go
+++ b/core/javascript_test.go
@@ -80,6 +80,11 @@ func BenchmarkJavascriptNoOp(b *testing.B) {
 			b.Errorf("Error %v", err)
 		}
 	}
+	// uncomment for a noisier benchmark, but gives greater insight to leaks
+	//mem := runtime.MemStats{}
+	//runtime.ReadMemStats(&mem)
+	//fmt.Printf("current goroutines: %d\n", runtime.NumGoroutine())
+	//fmt.Printf("memory statistics: %+v\n", mem)
 }
 
 func BenchmarkJavascriptLoop(b *testing.B) {


### PR DESCRIPTION
I've been profiling some code using rulio, and came across a low hanging optimization for javascript execution.  By default, the sister watchdog goroutines were being kept alive 60 seconds after an otto runtime exited.  This change is to ensure no extra resources are leaked in this path.  By disabling the `JavascriptTimeouts` parameter I saw a massive decrease in memory usage and an appreciable increase in throughput, although I haven't set up an equivalent test after this proposed patch.

I ran `BenchmarkJavascriptNoOp` to compare before and after.  Below are some sample findings from 61 second benchmarks:

|Category|Before|After|
----------|------|-----
|Goroutines|128477|3|
|Executions|258776|445980|
|execution time|218376ns|192894ns|

I have the full memory statistics for before and after, but I'm not going to pretend I understand them.  There are some appreciable differences though.
before:
```
{Alloc:41579682880 TotalAlloc:43533760304 Sys:44846953152 Lookups:0 Mallocs:422470458 Frees:10506785 HeapAlloc:41579682880 HeapSys:42086137856 HeapIdle:17981440 HeapInuse:42068156416 HeapReleased:17981440 HeapObjects:411963673 StackInuse:392200192 StackSys:392200192 MSpanInuse:683181992 MSpanSys:685867008 MCacheInuse:14400 MCacheSys:16384 BuckHashSys:1862674 GCSys:1606861352 OtherSys:74007686 NextGC:41482359568 LastGC:1620785680500991000 PauseTotalNs:1551306 PauseNs:[21530 53438 38824 81856 48845 58673 75800 134913 64231 92865 118299 91481 84706 70886 49508 106114 88800 93366 177171 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] PauseEnd:[1620785636240336000 1620785636240817000 1620785636242134000 1620785636247344000 1620785636252407000 1620785636263567000 1620785636274033000 1620785636303293000 1620785636352101000 1620785636436342000 1620785636592931000 1620785636862998000 1620785637505519000 1620785638894549000 1620785639305501000 1620785641655600000 1620785645660095000 1620785655406358000 1620785680500991000 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] NumGC:19 NumForcedGC:5 GCCPUFraction:0.0895881098038854 EnableGC:true DebugGC:false BySize:[{Size:0 Mallocs:0 Frees:0} {Size:8 Mallocs:269080 Frees:59} {Size:16 Mallocs:53776883 Frees:1559858} {Size:24 Mallocs:126103758 Frees:2597455} {Size:32 Mallocs:3764228 Frees:129931} {Size:48 Mallocs:60228730 Frees:779578} {Size:64 Mallocs:51893432 Frees:389778} {Size:80 Mallocs:1075569 Frees:259880} {Size:96 Mallocs:56733115 Frees:38} {Size:112 Mallocs:806846 Frees:260015} {Size:128 Mallocs:268977 Frees:92} {Size:144 Mallocs:806647 Frees:389750} {Size:160 Mallocs:268932 Frees:22} {Size:176 Mallocs:12 Frees:6} {Size:192 Mallocs:6 Frees:5} {Size:208 Mallocs:60 Frees:44} {Size:224 Mallocs:13 Frees:6} {Size:240 Mallocs:268877 Frees:0} {Size:256 Mallocs:42 Frees:24} {Size:288 Mallocs:983978 Frees:328813} {Size:320 Mallocs:22 Frees:12} {Size:352 Mallocs:57231722 Frees:1306157} {Size:384 Mallocs:728946 Frees:6} {Size:416 Mallocs:268891 Frees:10} {Size:448 Mallocs:4 Frees:1} {Size:480 Mallocs:1 Frees:0} {Size:512 Mallocs:268901 Frees:129935} {Size:576 Mallocs:537766 Frees:259826} {Size:640 Mallocs:15 Frees:10} {Size:704 Mallocs:1882145 Frees:779478} {Size:768 Mallocs:268881 Frees:3} {Size:896 Mallocs:18 Frees:11} {Size:1024 Mallocs:268900 Frees:22} {Size:1152 Mallocs:537774 Frees:1} {Size:1280 Mallocs:11 Frees:1} {Size:1408 Mallocs:1613265 Frees:259827} {Size:1536 Mallocs:13 Frees:13} {Size:1792 Mallocs:11 Frees:3} {Size:2048 Mallocs:24 Frees:23} {Size:2304 Mallocs:3 Frees:1} {Size:2688 Mallocs:537765 Frees:6} {Size:3072 Mallocs:0 Frees:0} {Size:3200 Mallocs:1 Frees:0} {Size:3456 Mallocs:3 Frees:3} {Size:4096 Mallocs:26 Frees:19} {Size:4864 Mallocs:3 Frees:3} {Size:5376 Mallocs:13 Frees:0} {Size:6144 Mallocs:4 Frees:3} {Size:6528 Mallocs:0 Frees:0} {Size:6784 Mallocs:0 Frees:0} {Size:6912 Mallocs:0 Frees:0} {Size:8192 Mallocs:14 Frees:7} {Size:9472 Mallocs:1 Frees:0} {Size:9728 Mallocs:0 Frees:0} {Size:10240 Mallocs:25 Frees:7} {Size:10880 Mallocs:0 Frees:0} {Size:12288 Mallocs:0 Frees:0} {Size:13568 Mallocs:13 Frees:7} {Size:14336 Mallocs:0 Frees:0} {Size:16384 Mallocs:0 Frees:0} {Size:18432 Mallocs:13 Frees:7}]}
```

After:
```
{Alloc:79749272 TotalAlloc:65351854288 Sys:217750568 Lookups:0 Mallocs:635510743 Frees:634454969 HeapAlloc:79749272 HeapSys:199720960 HeapIdle:105406464 HeapInuse:94314496 HeapReleased:59768832 HeapObjects:1055774 StackInuse:1605632 StackSys:1605632 MSpanInuse:1573656 MSpanSys:2326528 MCacheInuse:14400 MCacheSys:16384 BuckHashSys:1865186 GCSys:10451264 OtherSys:1764614 NextGC:131797776 LastGC:1620786810679903000 PauseTotalNs:228140056 PauseNs:[67166 82799 70503 95556 44088 82890 89318 95417 81760 48505 136834 117796 94452 114614 85256 65550 103421 58831 88446 85301 106873 54259 44975 67038 105213 55482 47760 67926 106021 82748 80627 53716 69264 86859 78391 71417 45624 69150 100993 66365 70478 84171 73239 70429 87214 92054 46662 75403 86594 67647 70550 85231 91521 95186 90547 68842 82241 66515 79086 89525 89302 64573 63040 92189 66550 69501 45793 78985 83796 79957 80156 59021 82889 50197 73761 67649 79357 69945 75099 76075 67447 74093 66635 76040 78166 69082 62557 88194 81002 77697 69972 68878 87120 41529 75778 79988 68583 42799 78347 96212 69486 61404 74022 54744 65500 60719 65888 42353 80994 70530 93700 41547 47173 62771 65244 90535 93351 88146 78916 74756 101596 71909 66214 65582 83595 69262 44663 83795 77058 65350 40187 65455 76561 80915 70649 87854 39373 44360 74359 68224 77976 65792 50435 69287 42719 73820 58728 74915 77712 37841 92600 65498 87840 69551 86078 82893 97602 89340 71706 65834 67394 76076 69115 65292 70470 72228 78357 73262 63750 67330 55032 70277 89774 65901 86455 75123 99051 68575 98301 96890 80395 69759 41605 88732 70906 69505 44966 59738 98391 40713 70424 70811 52400 72709 89152 79195 52879 66632 82520 76584 79520 67541 89090 87373 70615 59435 45995 93541 76388 70304 58982 68894 71642 96201 115600 68779 96633 97985 62509 72218 69395 80855 56643 68645 84674 81625 43675 74230 69239 72034 78642 71570 78850 93094 70814 82377 97698 50054 76545 78876 84604 66067 74422 69992 77961 41288 44377 81254 67960 90199 79517 65487 97351 83546 69486 67571] PauseEnd:[1620786810512004000 1620786810595754000 1620786810679903000 1620786789443847000 1620786789526856000 1620786789624789000 1620786789717889000 1620786789812816000 1620786789942114000 1620786790056320000 1620786790166947000 1620786790297502000 1620786790408919000 1620786790526331000 1620786790618226000 1620786790710319000 1620786790799701000 1620786790891653000 1620786790982873000 1620786791071302000 1620786791157360000 1620786791254885000 1620786791354880000 1620786791454149000 1620786791557028000 1620786791661266000 1620786791755886000 1620786791842059000 1620786791943331000 1620786792042493000 1620786792146314000 1620786792242944000 1620786792323849000 1620786792412525000 1620786792502833000 1620786792582001000 1620786792663420000 1620786792745978000 1620786792826520000 1620786792908388000 1620786792991321000 1620786793074495000 1620786793162259000 1620786793243641000 1620786793327640000 1620786793412143000 1620786793498022000 1620786793586468000 1620786793669856000 1620786793749794000 1620786793830476000 1620786793907886000 1620786793990631000 1620786794073995000 1620786794153691000 1620786794235684000 1620786794313609000 1620786794397006000 1620786794480120000 1620786794562414000 1620786794643426000 1620786794721680000 1620786794803636000 1620786794885788000 1620786794965653000 1620786795049509000 1620786795131920000 1620786795218413000 1620786795299870000 1620786795381536000 1620786795462863000 1620786795547484000 1620786795627620000 1620786795711340000 1620786795790847000 1620786795873185000 1620786795956295000 1620786796037857000 1620786796119984000 1620786796201196000 1620786796281214000 1620786796366323000 1620786796443915000 1620786796526387000 1620786796607429000 1620786796686717000 1620786796772620000 1620786796857170000 1620786796937741000 1620786797019337000 1620786797098752000 1620786797179878000 1620786797263959000 1620786797347201000 1620786797429630000 1620786797510726000 1620786797591912000 1620786797672323000 1620786797751551000 1620786797832097000 1620786797909186000 1620786797993346000 1620786798077591000 1620786798156248000 1620786798236655000 1620786798315306000 1620786798403915000 1620786798488014000 1620786798569109000 1620786798649136000 1620786798730596000 1620786798809762000 1620786798889470000 1620786798965964000 1620786799047554000 1620786799129047000 1620786799210070000 1620786799290014000 1620786799371367000 1620786799450951000 1620786799533277000 1620786799611916000 1620786799692269000 1620786799769621000 1620786799849701000 1620786799930611000 1620786800018067000 1620786800102956000 1620786800185508000 1620786800264823000 1620786800348757000 1620786800425740000 1620786800508087000 1620786800590729000 1620786800669772000 1620786800751217000 1620786800828262000 1620786800911225000 1620786800992326000 1620786801073366000 1620786801153386000 1620786801232023000 1620786801312624000 1620786801394862000 1620786801473324000 1620786801558240000 1620786801645427000 1620786801727300000 1620786801806575000 1620786801883537000 1620786801962669000 1620786802045361000 1620786802124372000 1620786802204010000 1620786802283193000 1620786802367872000 1620786802448605000 1620786802529032000 1620786802609728000 1620786802686662000 1620786802766919000 1620786802847334000 1620786802925950000 1620786803007254000 1620786803087963000 1620786803168051000 1620786803253752000 1620786803335970000 1620786803418091000 1620786803494366000 1620786803576047000 1620786803655556000 1620786803732974000 1620786803813104000 1620786803889129000 1620786803968467000 1620786804051371000 1620786804130549000 1620786804210730000 1620786804286994000 1620786804369885000 1620786804449696000 1620786804529955000 1620786804612912000 1620786804689411000 1620786804768539000 1620786804853845000 1620786804939476000 1620786805028997000 1620786805112014000 1620786805192235000 1620786805271164000 1620786805354375000 1620786805433511000 1620786805514390000 1620786805594412000 1620786805673461000 1620786805752542000 1620786805831350000 1620786805911664000 1620786805992289000 1620786806075558000 1620786806154670000 1620786806235076000 1620786806315144000 1620786806395150000 1620786806478706000 1620786806563742000 1620786806642186000 1620786806721219000 1620786806798134000 1620786806877636000 1620786806957442000 1620786807040126000 1620786807121907000 1620786807199583000 1620786807280067000 1620786807366536000 1620786807445808000 1620786807526084000 1620786807608081000 1620786807687435000 1620786807766389000 1620786807843255000 1620786807922712000 1620786807998412000 1620786808084457000 1620786808168646000 1620786808246428000 1620786808326397000 1620786808405067000 1620786808483267000 1620786808565046000 1620786808643724000 1620786808723418000 1620786808798828000 1620786808878393000 1620786808959291000 1620786809042701000 1620786809130680000 1620786809217572000 1620786809299800000 1620786809384278000 1620786809459533000 1620786809540974000 1620786809623160000 1620786809704607000 1620786809787706000 1620786809867177000 1620786809946214000 1620786810025519000 1620786810107079000 1620786810190416000 1620786810269017000 1620786810352988000 1620786810433696000] NumGC:3331 NumForcedGC:5 GCCPUFraction:0.0731898718272623 EnableGC:true DebugGC:false BySize:[{Size:0 Mallocs:0 Frees:0} {Size:8 Mallocs:404194 Frees:403945} {Size:16 Mallocs:80773013 Frees:80751447} {Size:24 Mallocs:189808724 Frees:189462536} {Size:32 Mallocs:5653620 Frees:5652091} {Size:48 Mallocs:90462010 Frees:90438323} {Size:64 Mallocs:77942643 Frees:77922248} {Size:80 Mallocs:1615449 Frees:1319290} {Size:96 Mallocs:86068111 Frees:85749285} {Size:112 Mallocs:1211756 Frees:1211417} {Size:128 Mallocs:403948 Frees:403835} {Size:144 Mallocs:1211559 Frees:1211241} {Size:160 Mallocs:403902 Frees:403764} {Size:176 Mallocs:12 Frees:7} {Size:192 Mallocs:5 Frees:4} {Size:208 Mallocs:62 Frees:48} {Size:224 Mallocs:13 Frees:9} {Size:240 Mallocs:403847 Frees:403742} {Size:256 Mallocs:44 Frees:25} {Size:288 Mallocs:1479733 Frees:1479345} {Size:320 Mallocs:22 Frees:12} {Size:352 Mallocs:85957142 Frees:85934780} {Size:384 Mallocs:808304 Frees:807489} {Size:416 Mallocs:403862 Frees:403753} {Size:448 Mallocs:4 Frees:1} {Size:480 Mallocs:1 Frees:0} {Size:512 Mallocs:403872 Frees:403766} {Size:576 Mallocs:807706 Frees:807486} {Size:640 Mallocs:15 Frees:10} {Size:704 Mallocs:2826935 Frees:2826196} {Size:768 Mallocs:403850 Frees:403744} {Size:896 Mallocs:18 Frees:11} {Size:1024 Mallocs:403871 Frees:403765} {Size:1152 Mallocs:807715 Frees:807485} {Size:1280 Mallocs:12 Frees:2} {Size:1408 Mallocs:2423085 Frees:2422455} {Size:1536 Mallocs:12 Frees:12} {Size:1792 Mallocs:12 Frees:5} {Size:2048 Mallocs:23 Frees:23} {Size:2304 Mallocs:4 Frees:2} {Size:2688 Mallocs:807704 Frees:807489} {Size:3072 Mallocs:1 Frees:1} {Size:3200 Mallocs:1 Frees:0} {Size:3456 Mallocs:2 Frees:2} {Size:4096 Mallocs:27 Frees:22} {Size:4864 Mallocs:2 Frees:2} {Size:5376 Mallocs:13 Frees:0} {Size:6144 Mallocs:5 Frees:4} {Size:6528 Mallocs:0 Frees:0} {Size:6784 Mallocs:0 Frees:0} {Size:6912 Mallocs:0 Frees:0} {Size:8192 Mallocs:15 Frees:13} {Size:9472 Mallocs:1 Frees:0} {Size:9728 Mallocs:0 Frees:0} {Size:10240 Mallocs:25 Frees:13} {Size:10880 Mallocs:0 Frees:0} {Size:12288 Mallocs:0 Frees:0} {Size:13568 Mallocs:12 Frees:12} {Size:14336 Mallocs:0 Frees:0} {Size:16384 Mallocs:0 Frees:0} {Size:18432 Mallocs:12 Frees:12}]}
```

As an aside: the profiling continues to indicate that the repeated creation of `otto` runtimes is a bottleneck for my sample data, and I plan on continuing to investigate to see whether the runtime can be reused in some manner.