### PR TITLE
Cache rules within State implementations for performance increases

### DIFF
--- a/core/location.go
+++ b/core/location.go
@@ -631,8 +631,8 @@ func duplicateId(msg string) error {
 	return fmt.Errorf("duplicate id %s", msg)
 }
 
-func (loc *Location) searchRulesAncestors(ctx *Context, event Map) (map[string]Map, error) {
-	acc := make(map[string]Map)
+func (loc *Location) searchRulesAncestors(ctx *Context, event Map) (map[string]*Rule, error) {
+	acc := make(map[string]*Rule)
 
 	// Local rules shadow those from parents.
 	err := loc.DoAncestors(ctx, func(parent *Location) error {
@@ -654,7 +654,7 @@ func (loc *Location) searchRulesAncestors(ctx *Context, event Map) (map[string]M
 	return acc, err
 }
 
-func (loc *Location) searchRules(ctx *Context, event Map) (map[string]Map, error) {
+func (loc *Location) searchRules(ctx *Context, event Map) (map[string]*Rule, error) {
 	ctx.SetLoc(loc)
 	Log(INFO, ctx, "Location.SearchRules", "location", loc.Name, "event", event)
 	if !loc.Enabled(ctx) {
@@ -670,7 +670,7 @@ func (loc *Location) searchRules(ctx *Context, event Map) (map[string]Map, error
 
 	var err error
 
-	acc, err := loc.state.FindRules(ctx, event)
+	acc, err := loc.state.FindCachedRules(ctx, event)
 	if err != nil {
 		Log(ERROR, ctx, "Location.SearchRules", "error", err, "location", loc.Name)
 	}
@@ -680,7 +680,7 @@ func (loc *Location) searchRules(ctx *Context, event Map) (map[string]Map, error
 	return acc, err
 }
 
-func (loc *Location) SearchRules(ctx *Context, event Map, includeInherited bool) (map[string]Map, error) {
+func (loc *Location) SearchRules(ctx *Context, event Map, includeInherited bool) (map[string]*Rule, error) {
 	// Chorus: Who then is ruler of necessity?
 	// Prometheus: The triple Fates and unforgetting Furies.
 	//
@@ -699,7 +699,7 @@ func (loc *Location) SearchRules(ctx *Context, event Map, includeInherited bool)
 	Inc(&loc.stats.TotalCalls, 1)
 	Inc(&loc.stats.SearchRules, 1)
 
-	var acc map[string]Map
+	var acc map[string]*Rule
 	var err error
 	if includeInherited {
 		acc, err = loc.searchRulesAncestors(ctx, event)

--- a/core/state.go
+++ b/core/state.go
@@ -39,6 +39,7 @@ type State interface {
 	get(ctx *Context, id string, getLock bool) (Map, error)
 	Search(ctx *Context, pattern Map) (*SearchResults, error)
 	FindRules(ctx *Context, event Map) (map[string]Map, error)
+	FindCachedRules(ctx *Context, event Map) (map[string]*Rule, error)
 	Clear(ctx *Context) error
 }
 

--- a/core/state_linear.go
+++ b/core/state_linear.go
@@ -398,7 +398,6 @@ func (s *LinearState) doFindRules(ctx *Context, event Map) (map[string]Map, erro
 
 //FindCachedRules functions similarly to FindRules, except that an in-memory cache is used
 // if a rule is not in the cache, it is added from persistence
-//TODO(racampbe): there is no cache invalidation.  updates to rules will never be realized.
 func (s *LinearState) FindCachedRules(ctx *Context, event Map) (map[string]*Rule, error) {
 	Log(DEBUG, ctx, "LinearState.FindCachedRules", "name", s.Name, "event", event)
 	timer := NewTimer(ctx, "LinearState.FindCachedRules")

--- a/sys/system.go
+++ b/sys/system.go
@@ -1233,16 +1233,16 @@ func (sys *System) SearchRules(ctx *Context, location string, event string, incl
 	var acc map[string]string
 	if err == nil {
 		Metric(ctx, "System.SearchRules", "location", location, "event", event)
-		var rules map[string]Map
+		var rules map[string]*Rule
 		rules, err = loc.SearchRules(ctx, m, includeInherited)
 		if err == nil {
 			acc = make(map[string]string, len(rules))
 			for id, rule := range rules {
-				var js string
-				if js, err = rule.JSON(); err != nil {
+				var js []byte
+				if js, err = json.Marshal(rule); err != nil {
 					break
 				}
-				acc[id] = js
+				acc[id] = string(js)
 			}
 		}
 	}


### PR DESCRIPTION
This resolves #76: more is discussed there.  The tl;dr is that repeated deserialization of rules containing `code` blocks causes slowdowns as each time the javascript code is compiled.  This change lazy-loads them into a cache as a `Rule` instead of a `Map`, and percolates the signature change upwards.

Anecdotally this yielded a roughly 80% throughput increase as many of our rules have `code` blocks.