### PR TITLE
WIP: Feat/pooled vms

### DIFF
--- a/core/actions.go
+++ b/core/actions.go
@@ -527,7 +527,7 @@ func GetCode(x interface{}) (string, error) {
 	case []string:
 		var acc string
 		for _, s := range vv {
-			acc += s + "\n"
+			acc += s + ";"
 		}
 		return acc, nil
 
@@ -538,7 +538,7 @@ func GetCode(x interface{}) (string, error) {
 			if !ok {
 				return "", fmt.Errorf("bad code %#v (%T)", y, y)
 			}
-			acc += s + "\n"
+			acc += s + ";"
 		}
 		return acc, nil
 

--- a/core/http_test.go
+++ b/core/http_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -45,7 +46,14 @@ func testHTTPRequest(t *testing.T, url string, shouldPass bool) {
 }
 
 func TestHTTPRequestBasic(t *testing.T) {
-	testHTTPRequest(t, "http://www.google.com", true)
+	wg := sync.WaitGroup{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wg.Done()
+	}))
+	defer server.Close()
+	wg.Add(1)
+	testHTTPRequest(t, server.URL, true)
+	wg.Wait()
 }
 
 func TestHTTPRequestBadURL(t *testing.T) {

--- a/core/javascript.go
+++ b/core/javascript.go
@@ -903,7 +903,6 @@ func RunJavascript(ctx *Context, bs *Bindings, props map[string]interface{}, src
 				}
 			case <-watchdogCleanup:
 			}
-			close(runtime.Interrupt)
 		}()
 	}
 

--- a/core/javascript.go
+++ b/core/javascript.go
@@ -128,7 +128,7 @@ func CompileJavascript(ctx *Context, loc *Location, libraries []string, code str
 	defer returnVM(runtime)
 
 	if SystemParameters.ScopedJavascriptRuntimes {
-		code = fmt.Sprintf("(function(){%s})()", code)
+		code = fmt.Sprintf(`(function(){return eval('%s')})()`, strings.ReplaceAll(code, "'", `\'`))
 	}
 	script, err := runtime.Compile("", code)
 	if nil != err {
@@ -525,7 +525,7 @@ func RunJavascript(ctx *Context, bs *Bindings, props map[string]interface{}, src
 
 	// if we're using reusable scoped runtimes and we're given uncompiled code, it needs to be wrapped
 	if srcString, ok := src.(string); ok && SystemParameters.ScopedJavascriptRuntimes {
-		src = fmt.Sprintf("(function(){%s})()", srcString)
+		src = fmt.Sprintf(`(function(){return eval('%s')})()`, strings.ReplaceAll(srcString, "'", `\'`))
 	}
 
 	runtime := getVM()

--- a/core/javascript.go
+++ b/core/javascript.go
@@ -128,7 +128,7 @@ func CompileJavascript(ctx *Context, loc *Location, libraries []string, code str
 	defer returnVM(runtime)
 
 	if SystemParameters.ScopedJavascriptRuntimes {
-		code = fmt.Sprintf(`(function(){return eval('%s')})()`, strings.ReplaceAll(strings.ReplaceAll(code, "'", `\'`), "\n", ";"))
+		code = fmt.Sprintf(`(function(){return eval('%s')})()`, strings.ReplaceAll(code, "'", `\'`))
 	}
 	script, err := runtime.Compile("", code)
 	if nil != err {
@@ -525,7 +525,7 @@ func RunJavascript(ctx *Context, bs *Bindings, props map[string]interface{}, src
 
 	// if we're using reusable scoped runtimes and we're given uncompiled code, it needs to be wrapped
 	if srcString, ok := src.(string); ok && SystemParameters.ScopedJavascriptRuntimes {
-		src = fmt.Sprintf(`(function(){return eval('%s')})()`, strings.ReplaceAll(strings.ReplaceAll(srcString, "'", `\'`), "\n", ";"))
+		src = fmt.Sprintf(`(function(){return eval('%s')})()`, strings.ReplaceAll(srcString, "'", `\'`))
 	}
 
 	runtime := getVM()

--- a/core/javascript.go
+++ b/core/javascript.go
@@ -128,7 +128,7 @@ func CompileJavascript(ctx *Context, loc *Location, libraries []string, code str
 	defer returnVM(runtime)
 
 	if SystemParameters.ScopedJavascriptRuntimes {
-		code = fmt.Sprintf(`(function(){return eval('%s')})()`, strings.ReplaceAll(code, "'", `\'`))
+		code = fmt.Sprintf(`(function(){return eval('%s')})()`, strings.ReplaceAll(strings.ReplaceAll(code, "'", `\'`), "\n", ";"))
 	}
 	script, err := runtime.Compile("", code)
 	if nil != err {
@@ -525,7 +525,7 @@ func RunJavascript(ctx *Context, bs *Bindings, props map[string]interface{}, src
 
 	// if we're using reusable scoped runtimes and we're given uncompiled code, it needs to be wrapped
 	if srcString, ok := src.(string); ok && SystemParameters.ScopedJavascriptRuntimes {
-		src = fmt.Sprintf(`(function(){return eval('%s')})()`, strings.ReplaceAll(srcString, "'", `\'`))
+		src = fmt.Sprintf(`(function(){return eval('%s')})()`, strings.ReplaceAll(strings.ReplaceAll(srcString, "'", `\'`), "\n", ";"))
 	}
 
 	runtime := getVM()

--- a/core/javascript_management.go
+++ b/core/javascript_management.go
@@ -1,0 +1,29 @@
+package core
+
+import (
+	"github.com/robertkrimen/otto"
+	"sync"
+)
+
+var _vmPool sync.Pool
+
+func init() {
+	_vmPool = sync.Pool{
+		New: func() interface{}{
+			return otto.New()
+		},
+	}
+}
+
+func getVM() *otto.Otto {
+	if !SystemParameters.ScopedJavascriptRuntimes {
+		return otto.New()
+	}
+	return _vmPool.Get().(*otto.Otto)
+}
+func returnVM(o *otto.Otto) {
+	if !SystemParameters.ScopedJavascriptRuntimes {
+		return
+	}
+	_vmPool.Put(o)
+}

--- a/core/javascript_test.go
+++ b/core/javascript_test.go
@@ -62,17 +62,8 @@ func TestRunJavascriptRunoffResult(t *testing.T) {
 	bs["x"] = 2
 	SystemParameters.ScopedJavascriptRuntimes = true
 
-	// reused/scoped runtimes no longer implicitly return a value
+	// reused/scoped runtimes should still implicitly return a value
 	val, err := RunJavascript(ctx, &bs,  nil, `x + 2`)
-	if err != nil {
-		t.Error(err)
-	}
-	if val != nil {
-		t.Errorf("expected nil result, got: %#v", val)
-	}
-
-	// explicitly returned values will regain previous behavior
-	val, err = RunJavascript(ctx, &bs,  nil, `return x + 2`)
 	if err != nil {
 		t.Error(err)
 	}
@@ -84,7 +75,6 @@ func TestRunJavascriptRunoffResult(t *testing.T) {
 	} else {
 		t.Errorf("expected return value to be a float, got: %#v", val)
 	}
-
 
 	SystemParameters.ScopedJavascriptRuntimes = false
 	val, err = RunJavascript(ctx, &bs,  nil, `x + 2`)

--- a/core/javascript_test.go
+++ b/core/javascript_test.go
@@ -117,6 +117,45 @@ func TestJavascriptBindingMutation(t *testing.T) {
 	}
 }
 
+func TestJavascriptMultiline(t *testing.T) {
+	bs := make(Bindings)
+	var val *int
+	val = new(int)
+	*val = 2
+	bs["x"] = val
+	SystemParameters.ScopedJavascriptRuntimes = true
+	v, err := RunJavascript(nil, &bs, nil, `
+x=x+1
+x=x+1
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *bs["x"].(*int) != 2 {
+		t.Errorf("Expected bindings not to be changed from javascript execution")
+	}
+	if v, ok := v.(float64); ok {
+		if v != 4 {
+			t.Errorf("expected 2+2=4, got: %f", v)
+		}
+	} else {
+		t.Errorf("expected return value to be a float, got: %#v", val)
+	}
+
+
+	SystemParameters.ScopedJavascriptRuntimes = false
+	_, err = RunJavascript(nil, &bs, nil, `
+x=x+1
+x=x+1
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *bs["x"].(*int) != 2 {
+		t.Errorf("Expected bindings not to be changed from javascript execution")
+	}
+}
+
 // verify that state doesn't leak between executions
 //note the `var` declaration used.
 func TestJavascriptStateMutation(t *testing.T) {

--- a/core/javascript_test.go
+++ b/core/javascript_test.go
@@ -24,26 +24,6 @@ import (
 	"testing"
 )
 
-//TODO(racampbe): don't commit this. use it as a code playground
-func TestDeleteme(t *testing.T) {
-	bs := make(Bindings)
-	bs["x"] = 2
-	SystemParameters.ScopedJavascriptRuntimes = true
-	_, err := RunJavascript(nil, &bs, nil, "x=x+1; if (x!=3) { Env.log('x is not 3: ' + x) }")
-	if err != nil {
-		t.Error(err)
-	}
-
-	_, err = RunJavascript(nil, &bs, nil, "x=x+1; if (x!=3) { Env.log('x is not 3: ' + x) }")
-	if err != nil {
-		t.Error(err)
-	}
-
-	_, err = RunJavascript(nil, &bs, nil, "x=x+1; if (x!=3) { Env.log('x is not 3: ' + x) }")
-	if err != nil {
-		t.Error(err)
-	}
-}
 
 // tests the 'out' javascript callable
 func TestJavascriptCommunication(t *testing.T) {

--- a/core/vars.go
+++ b/core/vars.go
@@ -140,6 +140,11 @@ type Parameters struct {
 	// CopyEvents will copy the binding for "?event" before giving
 	// that data to condition javascript or a javascript action.
 	CopyEvents bool
+
+	// ScopedJavascriptRuntimes causes the code to be placed within an anonymous function and reuse the javascript runtime.
+	// when enabled, explicit `return` statements are required.  Additionally, naked variable declaration via `x = 1`
+	// may leak into another code script.  variables should be declared with the `var` keyword.
+	ScopedJavascriptRuntimes bool
 }
 
 // Copy makes a shallow (except for DefaultControl) copy.
@@ -186,6 +191,7 @@ func DefaultParameters() *Parameters {
 	ps.HTTPRetryInterval = 20 * time.Second
 	ps.HTTPRetryOn = defaultRetryOn
 	ps.CopyEvents = true
+	ps.ScopedJavascriptRuntimes = false
 	return &ps
 }
 
@@ -217,7 +223,7 @@ func TightParameters() *Parameters {
 	ps.HTTPRetryInterval = 20 * time.Second
 	ps.HTTPRetryOn = defaultRetryOn
 	ps.CopyEvents = true
-
+	ps.ScopedJavascriptRuntimes = false
 	return &ps
 }
 

--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -356,9 +356,11 @@ the matching rule id respectively.
 
 The `code` is evaluated as a block, so the value of the last
 expression becomes the value of the code block.  No explicit `return`
-is needed or permitted.  If `code` is present, then a `libraries`
-property is supported as documented in
-[In-process Javascript actions](#in-process-javascript-actions).
+is needed or permitted by default.  If the `ScopedJavascriptRuntimes`
+parameter is set to true (default false), the Javascript will run in
+an anonymous function and must have a `return` for condition evaluation.
+If `code` is present, then a `libraries` property is supported as documented
+in [In-process Javascript actions](#in-process-javascript-actions).
 
 If the value returned by the block is truthy, then the condition
 evaluation continues.  In addition, if the value returned is an

--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -358,9 +358,10 @@ The `code` is evaluated as a block, so the value of the last
 expression becomes the value of the code block.  No explicit `return`
 is needed or permitted by default.  If the `ScopedJavascriptRuntimes`
 parameter is set to true (default false), the Javascript will run in
-an anonymous function and must have a `return` for condition evaluation.
-If `code` is present, then a `libraries` property is supported as documented
-in [In-process Javascript actions](#in-process-javascript-actions).
+an anonymous function: `var` is required in declarations to prevent
+scope leakage. If `code` is present, then a `libraries` property is
+supported as documented in 
+[In-process Javascript actions](#in-process-javascript-actions).
 
 If the value returned by the block is truthy, then the condition
 evaluation continues.  In addition, if the value returned is an


### PR DESCRIPTION
Not worth an in-depth review yet, just looking to make sure I'm steering the implementation in a direction you'd want.

WIP until:
 - [ ] more input/discussion
 - [ ] ~~enable strict mode when the flag is set so that javascript will fail rather than leak context in `x = 1` declarations~~
  - ~~EDIT: otto doesn't understand strict mode. this will need a switch to goja.~~
  - DOUBLE EDIT: this is a huge pain in the butt, and does not justify the benefits of strict mode.  I'm giving up on this.  Alternative workaround will be parsing the rules into JSON and passing it through a linter.  This workaround will not be committed into rulio.
 - [X] wrap it in `return eval('%s')` so that `return` isn't required
 - [ ] manual correctness testing
 - [ ] performance comparison
 - [X] undo the "don't commit this" test...
 - [ ] code containing newlines aren't considered legal. blindly doing a string replace with a semicolon seems unwise...

There's some unrelated test cleanups to make it run faster, 0a4244c is the big ticket commit here.  happy to rip them out so that there's a single useful commit in this PR.